### PR TITLE
Add setting for Style/TrailingCommaInArguments.

### DIFF
--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -140,3 +140,6 @@ Metrics/PerceivedComplexity:
 Performance/Casecmp:
   Enabled: false
 
+# 最終行にもカンマを付ける
+Style/TrailingCommaInArguments:
+  EnforcedStyleForMultiline: comma


### PR DESCRIPTION
以下のようなケースで最終行にもカンマを付けるようにする提案です
```rb
hoge(
  1,
  2,
)
```