### PR TITLE
Style/ClassAndModuleChildren を無効化

### DIFF
--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -77,6 +77,14 @@ Style/AlignParameters:
 Style/MultilineMethodCallIndentation:
   EnforcedStyle: indented
 
+# - module 分割を強制すると以下の問題がある
+#   - インデントが深くなる
+#   - 自動生成で Hoge::Fuga のように生成されることがある
+# - module に分割したいケースがある
+# 上記のような理由から、 "module Hoge { module Fuga {" と "module Hoge::Fuga" の両方を許容するため disable に
+Style/ClassAndModuleChildren:
+  Enabled: false
+
 #
 # Lint
 #
@@ -139,4 +147,3 @@ Metrics/PerceivedComplexity:
 # パフォーマンスのメリットよりcasecmpを使った時のわかりづらさのデメリットのほうが大きい
 Performance/Casecmp:
   Enabled: false
-


### PR DESCRIPTION
### 更新理由
```rb
class Hoge::Fuga
```
```rb
module Hoge 
  class Fuga
```
上記どちらのケースもメリットがあるため、Style/ClassAndModuleChildren を無効化します。

### class Hoge::Fuga のメリット
- ネストが深くならない
- 自動生成でこの形で生成されるケースがある

### module に分割されている場合のメリット
```rb
module Hoge
  PIYO = "piyo".freeze

  class Fuga
```
のように Hoge にも記述を書くことが出来る