### PR TITLE
Disable Style/NumericPredicate

### DIFF
--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -85,6 +85,12 @@ Style/MultilineMethodCallIndentation:
 Style/ClassAndModuleChildren:
   Enabled: false
 
+# num.positive? が num > 0 と比較したときに必ずしも同じニュアンスにならない。
+# positive?/negative?を使わない設定にしてもいいがzero?は使いたいケースがあるので
+# ルール自体をdisableにする
+Style/NumericPredicate
+  Enabled: false
+
 #
 # Lint
 #


### PR DESCRIPTION
positive?と> 0で案外ニュアンスが変わるのでdisableにする。

具体的には

num.positive? && num < 10

と書いた時と

0 < num && num < 10

と書いた時で、後者は境界値としての0が明確だが
前者は0より大きい数値全体を含んだ表現になるので少し意味が曖昧になる（感じがする）

あと、多分誰もpositive?/negative?を使ってない気がする。