### PR TITLE
Disabled percent literal delimiters

### DIFF
--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -91,6 +91,12 @@ Style/ClassAndModuleChildren:
 Style/NumericPredicate:
   Enabled: false
 
+
+# 0.48.1でデフォルトの挙動(`[]`がデフォルトにった)が変わったため、`()`に揃えるようにする
+Style/PercentLiteralDelimiters:
+  PreferredDelimiters:
+    '%i': ()
+
 #
 # Lint
 #


### PR DESCRIPTION
rubocopがデフォルトの挙動を変更したためそれに追従する変更です。
またhoundci上のrubocopのバージョンと違う模様で手元(0.48.1)ではパスしてるが、houndci上ではエラーになるので上記の理由と合わせて、disabledにします。