### PR TITLE
Disable Rails/ReversibleMigration

### DIFF
--- a/config/rubocop_rails.yml
+++ b/config/rubocop_rails.yml
@@ -9,3 +9,8 @@ Rails/SaveBang:
 # なるべくRuby標準のメソッドを使う
 Rails/SafeNavigation:
   ConvertTry: true
+
+# マイグレーションのdownを使うことがないため
+# わざわざreversibleにする理由がない
+Rails/ReversibleMigration:
+  Enabled: false


### PR DESCRIPTION
- マイグレーションの運用でdownを使わないため、reversibleに保つ理由がない