### PR TITLE
Rails5用のcopsをdisableにする

### DIFF
--- a/config/rubocop_rails.yml
+++ b/config/rubocop_rails.yml
@@ -9,6 +9,3 @@ Rails/SaveBang:
 # なるべくRuby標準のメソッドを使う
 Rails/SafeNavigation:
   ConvertTry: true
-
-Rails/HttpPositionalArguments:
-  Enabled: false # Rails5ならtrueにする

--- a/config/rubocop_rails4.yml
+++ b/config/rubocop_rails4.yml
@@ -1,0 +1,8 @@
+Rails/HttpPositionalArguments:
+  Enabled: false
+
+Rails/ApplicationJob:
+  Enabled: false
+
+Rails/ApplicationRecord:
+  Enabled: false

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -1,3 +1,4 @@
 inherit_from:
   - 'config/rubocop.yml'
   - 'config/rubocop_rails.yml'
+  - 'config/rubocop_rails4.yml' # Rails5の場合削除


### PR DESCRIPTION
- 弊社ではまだまだRails4がメインなのでdisableにする
- Rails5のプロジェクトでは.rubocop.ymlからrubocop_rails4.ymlの読み込みを削除すること